### PR TITLE
added type: cv (although wasn't sure if type 2 was needed?)

### DIFF
--- a/morgan/roster.json
+++ b/morgan/roster.json
@@ -20,7 +20,12 @@
     },
     {
       "name": "Harrison Grant",
-      "github": "harryg15"
+      "github": "harryg15",
+      "materials": [
+        {
+          "type": "cv"
+        }
+      ]
     },
     {
       "name": "Dobre Daiana-Melania",
@@ -75,7 +80,7 @@
     },
     {
       "name": "Elliot Heath",
-      "github": "eheath30"
+      "github": "eheath30",
       "materials" : [
       {
         "type": "cv"


### PR DESCRIPTION
The picture on PDF (career readiness) shows to write "type": "cv", whereas the instructions had "type2" in the paragraph as the key. Followed the picture instead.